### PR TITLE
add a flag by default using monolingual LM to score monolingual AM

### DIFF
--- a/egs/discophone/v1/decode_gmm.sh
+++ b/egs/discophone/v1/decode_gmm.sh
@@ -5,7 +5,7 @@
 set -eou pipefail
 
 stage=0
-
+use_monolm=true # if false, use multilingual phonotactic model
 langs_config="" # conf/experiments/all-ipa.conf
 if [ $langs_config ]; then
   # shellcheck disable=SC1090


### PR DESCRIPTION
Fix a missing flag variable definition denoting whether use monolingual LM or multilingual LM to score AM.